### PR TITLE
DHFPROD-2135: MLCP clipboard fixes

### DIFF
--- a/web/src/main/ui/app/app.module.ts
+++ b/web/src/main/ui/app/app.module.ts
@@ -70,7 +70,6 @@ import {ManageJobsService} from './components/jobs-new/manage-jobs.service';
 import {ProjectService} from './services/projects';
 import { RunningJobService } from './components/jobs-new/services/running-job-service';
 import {STOMPService} from './services/stomp';
-import {ClipboardDirective} from './directives/clipboard/clipboard.directive';
 import {TraceService} from './components/traces/trace.service';
 import {SearchService} from './components/search/search.service';
 import {HarmonizeFlowOptionsComponent} from './components/harmonize-flow-options';
@@ -137,7 +136,6 @@ import {FolderBrowserModule} from "./components/folder-browser/folder-browser.mo
     SearchViewerComponent,
     SearchViewerUiComponent,
     NoContentComponent,
-    ClipboardDirective,
     HarmonizeFlowOptionsComponent,
     HarmonizeFlowOptionsUiComponent,
     DashboardComponent,

--- a/web/src/main/ui/app/components/flows-new/edit-flow/edit-flow.module.ts
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/edit-flow.module.ts
@@ -14,6 +14,7 @@ import {NewStepDialogUiComponent} from './ui/new-step-dialog-ui.component';
 import {RunFlowDialogComponent} from './ui/run-flow-dialog.component';
 import {StepComponent} from './ui/step.component';
 import {StepperComponent} from './ui/stepper.component';
+import {ClipboardDirective} from '../../../directives/clipboard/clipboard.directive';
 
 import {MatchingComponent} from './mastering/matching/matching.component';
 import {MatchOptionsUiComponent} from './mastering/matching/ui/match-options-ui.component';
@@ -72,7 +73,8 @@ import {AppCommonModule} from "../../common";
     ListFilterPipe,
     TruncateCharactersPipe,
     CustomComponent,
-    CustomUiComponent
+    CustomUiComponent,
+    ClipboardDirective
   ],
   imports: [
     CommonModule,
@@ -92,7 +94,8 @@ import {AppCommonModule} from "../../common";
   exports: [
     FocusElementDirective,
     ListFilterPipe,
-    TruncateCharactersPipe
+    TruncateCharactersPipe,
+    ClipboardDirective
   ],
   providers: [],
   entryComponents: [

--- a/web/src/main/ui/app/components/flows-new/edit-flow/ingest/ui/ingest-ui.component.html
+++ b/web/src/main/ui/app/components/flows-new/edit-flow/ingest/ui/ingest-ui.component.html
@@ -37,7 +37,7 @@
       </mat-select>
     </mat-form-field>
 
-    <div *ngIf="this.step.fileLocations.inputFileType === 'csv'">
+    <!--<div *ngIf="this.step.fileLocations.inputFileType === 'csv'">
       <div class="label"
         [matTooltip]="tooltips.separator"
         matTooltipPosition="left"
@@ -60,7 +60,7 @@
           </mat-option>
         </mat-select>
       </mat-form-field>
-    </div>
+    </div> -->
 
     <div class="label"
       [matTooltip]="tooltips.targetType"


### PR DESCRIPTION
- Move Clipboard declaration to edit-flow.module.ts and export so others can still use
- Temporarily comment out CSV form field, that is causing errors, need to fix